### PR TITLE
fix: remove need to press button to join in co-op

### DIFF
--- a/Assets/Game/Prefabs/Systems/GameManager.prefab
+++ b/Assets/Game/Prefabs/Systems/GameManager.prefab
@@ -88,7 +88,7 @@ MonoBehaviour:
   m_NotificationBehavior: 0
   m_MaxPlayerCount: 2
   m_AllowJoining: 0
-  m_JoinBehavior: 0
+  m_JoinBehavior: 1
   m_PlayerJoinedEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -98,13 +98,77 @@ MonoBehaviour:
   m_JoinAction:
     m_UseReference: 0
     m_Action:
-      m_Name: 
+      m_Name: Join
       m_Type: 0
       m_ExpectedControlType: 
       m_Id: 33a6e03d-8bfa-4796-bb50-898dd1b1109b
       m_Processors: 
       m_Interactions: 
-      m_SingletonActionBindings: []
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 16d28854-34fe-46a7-a187-b3670dede03b
+        m_Path: <Gamepad>/leftStick
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
+      - m_Name: 
+        m_Id: dd5f2444-bfd8-4b6e-99b3-c20755d3f58f
+        m_Path: <Gamepad>/rightStick
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
+      - m_Name: 
+        m_Id: 460b35cb-317a-42fb-ac67-1954c281e3f9
+        m_Path: <Keyboard>/anyKey
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
+      - m_Name: 
+        m_Id: fd9bbf95-76df-4996-b7d4-4cf7ed5051a2
+        m_Path: <Gamepad>/dpad
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
+      - m_Name: 
+        m_Id: c3345480-6022-4f4a-bbec-b8b99bfe86c0
+        m_Path: <Gamepad>/buttonEast
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
+      - m_Name: 
+        m_Id: aeb745dc-3602-40b3-a5d8-4fb92a85d663
+        m_Path: <Gamepad>/buttonNorth
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
+      - m_Name: 
+        m_Id: 66579b97-2e74-41aa-a0d7-dc9d5372eea0
+        m_Path: <Gamepad>/buttonSouth
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
+      - m_Name: 
+        m_Id: c57c2fa0-6284-4790-b223-c4dd8ab63c96
+        m_Path: <Gamepad>/buttonWest
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
       m_Flags: 0
     m_Reference: {fileID: 0}
   m_PlayerPrefab: {fileID: 5158904645978587220, guid: a77c1427e4428ba408c629056e51af2b,

--- a/Assets/Game/Scripts/UI/Menus/PauseMenu.cs
+++ b/Assets/Game/Scripts/UI/Menus/PauseMenu.cs
@@ -43,7 +43,10 @@ namespace Game.Scripts.UI.Menus
 
             var mainMenuButton = options.Create<Button>("main-button");
             mainMenuButton.text = "Main Menu";
-            mainMenuButton.ApplyClickCallbacks(() => GameManager.Instance.ChangeState(new MainMenuState(), false, true));
+            mainMenuButton.RegisterCallback<ClickEvent>(_ => 
+                GameManager.Instance.ChangeState(new MainMenuState(), false, true));
+            mainMenuButton.RegisterCallback<NavigationSubmitEvent>(_ => 
+                GameManager.Instance.ChangeState(new MainMenuState(), false, true));
             
             if (preventOverflowNavigation)
             {


### PR DESCRIPTION
Joining the game while in co-op mode no longer requires that the player press a button if they are using a gamepad.

Also fixes a minor issue with the pause menu callbacks being set up incorrectly.